### PR TITLE
Update shared.js

### DIFF
--- a/preview/shared.js
+++ b/preview/shared.js
@@ -9,6 +9,9 @@ var exampleAPIcodes = {
 	'Jawg': {
 		'accessToken': 'PyTJUlEU1OPJwCJlW1k0NC8JIt2CALpyuj7uc066O7XbdZCjWEL3WYJIk6dnXtps'
 	},
+	'MapTilesAPI': {
+		'apikey': '91eb180eb9msh46beac27e6084cep17a106jsn18a17417dbb6'
+	},
 	'Thunderforest': {
 		'apikey': 'db5ae1f5778a448ca662554581f283c5'
 	}


### PR DESCRIPTION
Added example api key for MapTiles API. This key is not to be used in production by third parties but just for leaflet-providers.